### PR TITLE
[MIT] seg fault while retrieving KDC host

### DIFF
--- a/krb525_convert.c
+++ b/krb525_convert.c
@@ -280,7 +280,7 @@ get_krb525_endpoints(krb5_context context, short port, char *realm, krb525_endpo
 		data_realm.length = strlen(realm);
 
 		/* N.B. there's a different location of the directive! */
-		krb5_appdefault_string(context, NULL, &data_realm, "krb525_server", NULL, &s);
+		krb5_appdefault_string(context, NULL, &data_realm, "krb525_server", "", &s);
 		krb525_hosts = calloc(2, sizeof(*krb525_hosts));
 		if (krb525_hosts == NULL) {
 			retval = ENOMEM;
@@ -291,7 +291,7 @@ get_krb525_endpoints(krb5_context context, short port, char *realm, krb525_endpo
 	}
 #endif
 
-	if (!krb525_hosts || !krb525_hosts[0]) {
+	if (!krb525_hosts || !krb525_hosts[0] || !*krb525_hosts[0]) {
 		retval = KRB5_KDC_UNREACH;
 		goto end;
 	}


### PR DESCRIPTION
**Problem description:**
Using the MIT client with no default krb525 server set, there is a segmentation fault happened while the KDC host is retrieved:

Reading symbols from ./krb525_renew...done.
(gdb) r
Starting program: /root/mit/krb525/krb525_renew test@PBSPRO
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
strlen () at ../sysdeps/x86_64/strlen.S:106
106	../sysdeps/x86_64/strlen.S: No such file or directory.
(gdb) bt
#0  strlen () at ../sysdeps/x86_64/strlen.S:106
#1  0x00007ffff75dc3ae in __GI___strdup (s=0x0) at strdup.c:41
#2  0x00007ffff7936cb8 in krb5_appdefault_string () from /usr/lib/x86_64-linux-gnu/libkrb5.so.3
#3  0x000055555555795b in get_krb525_endpoints (context=0x55555575b100, port=0, 
    realm=0x55555575c2e0 "PBSPRO", krb525_endpoints=0x7fffffffe848) at krb525_convert.c:283
#4  0x0000555555558214 in krb525_convert_with_ccache (context=0x55555575b100, hosts=0x0, port=0, 
    ccache=0x55555575fdd0, cname=0x0, in_creds=0x55555575c530, out_creds=0x7fffffffe9e0)
    at krb525_convert.c:529
#5  0x0000555555558510 in krb525_get_creds_ccache (context=0x55555575b100, ccache=0x55555575fdd0, 
    in_creds=0x55555575c530, out_creds=0x7fffffffe9e0) at krb525_convert.c:611
#6  0x0000555555556b44 in convert_creds (context=0x55555575b100, initiator_creds=0x7fffffffea60, 
    target_creds=0x7fffffffe9e0) at renew.c:284
#7  0x0000555555556e49 in doit (user=0x7fffffffee36 "test@PBSPRO") at renew.c:351
#8  0x0000555555556f17 in main (argc=2, argv=0x7fffffffec08) at renew.c:377
(gdb) 

**Solution:**
krb5_appdefault_string() does not accept NULL as a default string, which means empty string "" is suitable instead and we will check zero length of the string later. 

**Comment:**
Unfortunately, [MIT library](http://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/index.html) does not provide a function similar to krb5_get_krbhst() (Heimdal), and I think there is only one reasonable way how to retrieve the KDC hostname with MIT, which is to rely on the default configuration of krb525 server in krb5.conf.

