### PR TITLE
miscellaneous fixes for debian buster

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ libkrb525_la_SOURCES = krb525_convert.c \
 libkrb525_la_LIBADD = $(K5LIBPATH) $(KRB5LIBS)
 
 krb525_SOURCES = client.c 
-krb525_LDADD = $(top_builddir)/.libs/libkrb525.a $(K5LIBPATH) $(KRB5LIBS) $(com_err_LIBS) $(SYSLIBS)
+krb525_LDADD = libkrb525.la $(top_builddir)/.libs/libkrb525.a $(K5LIBPATH) $(KRB5LIBS) $(com_err_LIBS) $(SYSLIBS)
 
 krb525_renew_SOURCES = renew.c base64.c
 krb525_renew_LDADD = $(krb525_LDADD)

--- a/h_db.c
+++ b/h_db.c
@@ -75,6 +75,8 @@ hdb_get_key(krb5_context context,
   krb5_error_code ret;
   Key  *k;
 
+  memset(&entry, 0, sizeof(entry));
+
   *key = (krb5_keyblock *) malloc(sizeof(krb5_keyblock));
   if (*key == NULL) {
     sprintf(k5_db_error, "malloc failed");


### PR DESCRIPTION
* Running 'make' on Debian 10, an error occurs:
```
make[2]: *** No rule to make target '.libs/libkrb525.a', needed by 'krb525'.  Stop.
make[2]: Leaving directory '/root/krb525'
make[1]: *** [Makefile:430: all] Error 2
make[1]: Leaving directory '/root/krb525'
make: *** [debian/rules:34: build-stamp] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
```
'make libkrb525.la' creates .libs/*.

* Using krb525d on Debian 10, a segfault occurs:
```
==22334== Conditional jump or move depends on uninitialised value(s)
==22334==    at 0x49B64A3: hdb_free_entry (in /usr/lib/x86_64-linux-gnu/libhdb.so.9.2.0)
==22334==    by 0x49B097A: ??? (in /usr/lib/x86_64-linux-gnu/libhdb.so.9.2.0)
==22334==    by 0x10D020: hdb_get_entry (h_db.c:112)
==22334==    by 0x10D124: hdb_get_key (h_db.c:84)
==22334==    by 0x10AD36: main (server.c:467)
==22334== 
==22334== Use of uninitialised value of size 8
==22334==    at 0x49B64A5: hdb_free_entry (in /usr/lib/x86_64-linux-gnu/libhdb.so.9.2.0)
==22334==    by 0x598E34F: ???
==22334==    by 0x49B097A: ??? (in /usr/lib/x86_64-linux-gnu/libhdb.so.9.2.0)
==22334==    by 0x10D020: hdb_get_entry (h_db.c:112)
==22334==    by 0x10D124: hdb_get_key (h_db.c:84)
==22334==    by 0x10AD36: main (server.c:467)
==22334== 
==22334== 
==22334== Process terminating with default action of signal 11 (SIGSEGV)
==22334==  Bad permissions for mapped region at address 0x1FFEFFE810
==22334==    at 0x1FFEFFE810: ???
==22334==    by 0x59B0B8F: ???
==22334== Invalid free() / delete / delete[] / realloc()
==22334==    at 0x48369AB: free (vg_replace_malloc.c:530)
==22334==    by 0x4DBFAB9: free_key_mem (dlerror.c:223)
==22334==    by 0x4DBFAB9: __dlerror_main_freeres (dlerror.c:239)
==22334==    by 0x4B43B71: __libc_freeres (in /usr/lib/x86_64-linux-gnu/libc-2.28.so)
==22334==    by 0x482B19E: _vgnU_freeres (vg_preloaded.c:77)
==22334==    by 0x49B64A6: hdb_free_entry (in /usr/lib/x86_64-linux-gnu/libhdb.so.9.2.0)
==22334==    by 0x49B097A: ??? (in /usr/lib/x86_64-linux-gnu/libhdb.so.9.2.0)
==22334==    by 0x10D020: hdb_get_entry (h_db.c:112)
==22334==    by 0x10D124: hdb_get_key (h_db.c:84)
==22334==    by 0x10AD36: main (server.c:467)
==22334==  Address 0x1ffeffe6a0 is on thread 1's stack
==22334==  in frame #7, created by hdb_get_key (h_db.c:73)
```
The 'entry' should be initialized with zeros before using.
