### PR TITLE
add configurable TCP connection timeout

### DIFF
--- a/client.c
+++ b/client.c
@@ -167,6 +167,7 @@ char *argv[];
 	char *krb525_host = NULL;
 	char **krb525_hosts = NULL;
 	int krb525_port = KRB525_PORT;
+	int krb525_timeout = 0;
 
 	/* Credentials we are converting */
 	char *cname = NULL;
@@ -217,7 +218,7 @@ char *argv[];
 		progname = argv[0];
 
 	/* Process arguments */
-	while ((arg = getopt(argc, argv, "aAc:C:g:h:i:ko:p:s:S:t:u:vVr:")) != EOF)
+	while ((arg = getopt(argc, argv, "aAc:C:g:h:i:ko:p:s:S:t:T:u:vVr:")) != EOF)
 		switch (arg) {
 		case 'a':
 #ifdef AFS_KRB5
@@ -281,6 +282,14 @@ char *argv[];
 			keytab_name = optarg;
 			break;
 
+		case 'T':
+			krb525_timeout = atoi(optarg);
+			if (krb525_timeout < 1) {
+				fprintf(stderr, "timeout must be greater then 0\n");
+				arg_error++;
+			}
+			break;
+
 		case 'u':
 			cache_owner = optarg;
 			break;
@@ -338,6 +347,7 @@ char *argv[];
 			"   -s <service name>        Service for credentials to convert\n"
 			"   -S <target service>      Service to convert to\n"
 			"   -t <keytab file>         Keytab file to use\n"
+			"   -T <tcp timeout>         TCP connection timeout\n"
 			"   -u <username>            Specify owner of output cache\n"
 			"   -v                       Verbose mode\n"
 			"   -V                       Print version and exit\n", progname);
@@ -663,8 +673,8 @@ char *argv[];
 	target_creds.server = target_sprinc;
 	if (!use_keytab)
 		retval = krb525_convert_with_ccache(context,
-						    krb525_hosts,
-						    krb525_port, source_ccache, cname, &creds, &target_creds);
+						    krb525_hosts, krb525_port, krb525_timeout,
+						    source_ccache, cname, &creds, &target_creds);
 	else
 		/* Not sure what's supposed to be done with the keytab,
 		   initial creds were already obtained above. */

--- a/client.c
+++ b/client.c
@@ -167,7 +167,7 @@ char *argv[];
 	char *krb525_host = NULL;
 	char **krb525_hosts = NULL;
 	int krb525_port = KRB525_PORT;
-	int krb525_timeout = 0;
+	int krb525_timeout = -1;
 
 	/* Credentials we are converting */
 	char *cname = NULL;
@@ -284,8 +284,8 @@ char *argv[];
 
 		case 'T':
 			krb525_timeout = atoi(optarg);
-			if (krb525_timeout < 1) {
-				fprintf(stderr, "timeout must be greater then 0\n");
+			if (krb525_timeout < 0) {
+				fprintf(stderr, "timeout must be greater or equal 0\n");
 				arg_error++;
 			}
 			break;

--- a/krb525.1
+++ b/krb525.1
@@ -14,7 +14,8 @@ krb525 \- Convert clients or servers on a Kerberos 5 ticket
 [\fB\-h\fP \fIserver_host\fP] [\fB\-i\fP \fIinput_cache\fP]
 [\fB\-k\fP] [\fB\-o\fP \fIoutput_cache\fP] [\fB\-p\fP \fIserver_port\fP]
 [\fB\-s\fP \fIservice\fP] [\fB\-S\fP \fItarget_service\fP]
-[\fB\-t\fP \fIkeytab_file\fP] [\fB\-u\fP \fIusername\fP] [\fB\-v\fP]
+[\fB\-t\fP \fIkeytab_file\fP] [\fB\-T\fP \fItimeout\fP]
+[\fB\-u\fP \fIusername\fP] [\fB\-v\fP]
 [\fB\-V\fP]
 .br
 .SH DESCRIPTION
@@ -118,6 +119,9 @@ specifies the keytab file to be used is
 Note that the 
 .B -k
 option must be specified for this to be meaningful.
+.TP
+\fB\-T\fP \fItimeout\fP
+specifies the TCP connection timeout in seconds. Must be greater then 0.
 .TP
 \fB\-u\fP \fIuser\fP
 specifies the owner of the resulting credentials file should be

--- a/krb525.1
+++ b/krb525.1
@@ -121,7 +121,7 @@ Note that the
 option must be specified for this to be meaningful.
 .TP
 \fB\-T\fP \fItimeout\fP
-specifies the TCP connection timeout in seconds. Must be greater then 0.
+specifies the TCP connection timeout in seconds. Must be greater or equal 0.
 .TP
 \fB\-u\fP \fIuser\fP
 specifies the owner of the resulting credentials file should be

--- a/krb525.h
+++ b/krb525.h
@@ -12,6 +12,8 @@
 
 #define KRB525_PORT		6565
 
+#define TCP_DEFAULT_TIMEOUT		5
+
 /*
  * Version string for sendauth/recvauth
  */

--- a/krb525.h
+++ b/krb525.h
@@ -12,7 +12,7 @@
 
 #define KRB525_PORT		6565
 
-#define TCP_DEFAULT_TIMEOUT		5
+#define TCP_DEFAULT_TIMEOUT	5
 
 /*
  * Version string for sendauth/recvauth

--- a/krb525_convert.c
+++ b/krb525_convert.c
@@ -302,19 +302,15 @@ get_krb525_endpoints(krb5_context context, short port, int timeout, char *realm,
 
 
 static int
-get_krb525_timeout(krb5_context context, char *realm)
+get_krb525_timeout(krb5_context context)
 {
 	int timeout;
 	char default_s[sizeof(int) + 1];
 	char *s;
-	krb5_data data_realm;
 
 	sprintf(default_s, "%d", TCP_DEFAULT_TIMEOUT);
 
-	data_realm.data = realm;
-	data_realm.length = strlen(realm);
-
-	krb5_appdefault_string(context, NULL, &data_realm, "krb525_timeout", default_s, &s);
+	krb5_appdefault_string(context, NULL, NULL, "krb525_timeout", default_s, &s);
 
 	timeout = atoi(s);
 
@@ -514,7 +510,7 @@ krb525_convert_with_ccache(krb5_context context,
 #endif
 
 	if (timeout < 1) {
-		timeout = get_krb525_timeout(context, realm);
+		timeout = get_krb525_timeout(context);
 	}
 
 	if (hosts)

--- a/krb525_convert.c
+++ b/krb525_convert.c
@@ -314,8 +314,8 @@ get_krb525_timeout(krb5_context context)
 
 	timeout = atoi(s);
 
-	if (timeout < 1) {
-		timeout = TCP_DEFAULT_TIMEOUT;
+	if (timeout < 0) {
+		timeout = 0;
 	}
 
 	return timeout;
@@ -509,7 +509,7 @@ krb525_convert_with_ccache(krb5_context context,
 	realm = in_creds->server->realm.data;
 #endif
 
-	if (timeout < 1) {
+	if (timeout < 0) {
 		timeout = get_krb525_timeout(context);
 	}
 

--- a/krb525_convert.h
+++ b/krb525_convert.h
@@ -17,7 +17,7 @@ krb5_error_code
 krb525_convert_with_ccache(krb5_context context,
 			   char         **hosts,
 			   int          port,
-			   int 			timeout,
+			   int          timeout,
 			   krb5_ccache  ccache,
 			   char         *cname,
 			   krb5_creds   *in_creds,

--- a/krb525_convert.h
+++ b/krb525_convert.h
@@ -17,6 +17,7 @@ krb5_error_code
 krb525_convert_with_ccache(krb5_context context,
 			   char         **hosts,
 			   int          port,
+			   int 			timeout,
 			   krb5_ccache  ccache,
 			   char         *cname,
 			   krb5_creds   *in_creds,
@@ -35,7 +36,8 @@ krb5_error_code
 krb525_get_creds_ccache(krb5_context context,
 			krb5_ccache  ccache,
 			krb5_creds  *in_creds,
-			krb5_creds  *out_creds);
+			krb5_creds  *out_creds,
+			int         timeout);
 
 krb5_error_code
 krb525_get_creds_keytab(krb5_context context,

--- a/krb525d.8
+++ b/krb525d.8
@@ -25,6 +25,9 @@ krb525d \- Kerberos V5 Ticket translater daemon
 .B \-t
 .I keytab_name
 ] [
+.B \-T
+.I timeout
+] [
 .B \-V
 ]
 .br
@@ -82,6 +85,9 @@ local keytab file.
 \fB\-t\fP \fIkeytab_name\fP
 specifies the name of the keytab file to be used by
 .IR krb525d .
+.TP
+\fB\-T\fP \fItimeout\fP
+specifies the TCP connection timeout in seconds. Must be greater then 0.
 .TP
 .B \-V
 specifies that

--- a/krb525d.8
+++ b/krb525d.8
@@ -87,7 +87,7 @@ specifies the name of the keytab file to be used by
 .IR krb525d .
 .TP
 \fB\-T\fP \fItimeout\fP
-specifies the TCP connection timeout in seconds. Must be greater then 0.
+specifies the TCP connection timeout in seconds. Must be greater or equal 0.
 .TP
 .B \-V
 specifies that

--- a/netio.c
+++ b/netio.c
@@ -204,10 +204,12 @@ connect_to_server(char *hostname, int port, int timeout)
 		return (-1);
 	}
 
-	tv.tv_sec = timeout;
-	tv.tv_usec = 0;
-	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&tv, sizeof tv);
-	setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const void*)&tv, sizeof tv);
+	if (timeout > 0) {
+		tv.tv_sec = timeout;
+		tv.tv_usec = 0;
+		setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&tv, sizeof tv);
+		setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const void*)&tv, sizeof tv);
+	}
 
 	/* connect to the server */
 	if (connect(sock, (struct sockaddr *)&sin, sizeof(sin)) < 0) {
@@ -238,10 +240,12 @@ make_accepting_sock(int port, int timeout)
 		return -1;
 	}
 
-	tv.tv_sec = timeout;
-	tv.tv_usec = 0;
-	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&tv, sizeof tv);
-	setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const void*)&tv, sizeof tv);
+	if (timeout > 0) {
+		tv.tv_sec = timeout;
+		tv.tv_usec = 0;
+		setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&tv, sizeof tv);
+		setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const void*)&tv, sizeof tv);
+	}
 
 	/* Let the socket be reused right away */
 	(void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *)&on, sizeof(on));

--- a/netio.h
+++ b/netio.h
@@ -32,11 +32,11 @@ extern int read_msg(krb5_context,
 
 extern int connect_to_server(char *,
 			     int,
-				 int);
+			     int);
 
 
 extern int make_accepting_sock(int,
-			     int);
+			       int);
 
 
 

--- a/netio.h
+++ b/netio.h
@@ -31,10 +31,12 @@ extern int read_msg(krb5_context,
 		    krb5_data *);
 
 extern int connect_to_server(char *,
+			     int,
+				 int);
+
+
+extern int make_accepting_sock(int,
 			     int);
-
-
-extern int make_accepting_sock(int);
 
 
 

--- a/renew.c
+++ b/renew.c
@@ -355,7 +355,7 @@ main(int argc, char *argv[])
 	int ret;
 	int ch;
 	int lifetime = 24 * 3600;
-	int timeout = 0;
+	int timeout = -1;
 
 	if ((progname = strrchr(argv[0], '/')))
 		progname++;
@@ -375,8 +375,8 @@ main(int argc, char *argv[])
 			break;
 		case 'T':
 			timeout = atoi(optarg);
-			if (timeout < 1) {
-				fprintf(stderr, "error: timeout must be greater then 0\n");
+			if (timeout < 0) {
+				fprintf(stderr, "error: timeout must be greater or equal 0\n");
 				exit(1);
 			}
 			break;

--- a/server.c
+++ b/server.c
@@ -64,7 +64,7 @@ char *argv[];
 	socklen_t namelen = sizeof(rsin);
 	int sock = -1;		/* incoming connection fd */
 	short port = 0;		/* If user specifies port */
-	int timeout = 0;	/* tcp connection timeout */
+	int timeout = TCP_DEFAULT_TIMEOUT;	/* tcp connection timeout */
 	struct timeval tv;
 
 	krb5_data resp_data;
@@ -230,10 +230,6 @@ char *argv[];
 #endif
 	}
 
-	if (timeout < 1) {
-		timeout = TCP_DEFAULT_TIMEOUT;
-	}
-
 	/* Read my configuration file */
 	if (init_conf(conf_file)) {
 		syslog(LOG_ERR, "Reading configuration file: %s", srv_conf_error);
@@ -313,10 +309,12 @@ char *argv[];
 		sock = 0;
 	}
 
-	tv.tv_sec = timeout;
-	tv.tv_usec = 0;
-	setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&tv, sizeof tv);
-	setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const void*)&tv, sizeof tv);
+	if (timeout > 0) {
+		tv.tv_sec = timeout;
+		tv.tv_usec = 0;
+		setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const void*)&tv, sizeof tv);
+		setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const void*)&tv, sizeof tv);
+	}
 
 	namelen = sizeof(lsin);
 	if (getsockname(sock, (struct sockaddr *)&lsin, &namelen) < 0) {


### PR DESCRIPTION
**Problem Description:**
The TCP connection uses default connection timeout, which can take too long. This problem can be visible especially when a secondary KDC server is set. If the first KDC server timeouts, the secondary is contacted after the timeout and thus the credentials can be supplied in dozens of seconds.

**Change Description:**
A configurable timeout has been added to both the server and clients. All krb525 components can set the timeout with the argument `-T <timeout_in_seconds>`. Moreover, the clients read the timeout from `krb5.conf`, section: `[appdefaults]`, parameter: `krb525_timeout`. The argument -T is prioritized. The default value is 5 seconds.

**Proof of Testing:**
* clients timeout, default value:
```
root@d12-pbs-server:~/krb525# iptables -A INPUT --src d12-kdc -p tcp --sport 6565 -j DROP
root@d12-pbs-server:~/krb525# time ./krb525_renew vchlum@PBSPRO 
Failed to translate ticket: Failed to connect to server d12-kdc (Operation now in progress)
.

real	0m5.038s
user	0m0.010s
sys	0m0.006s
root@d12-pbs-server:~/krb525# time ./krb525 -i /tmp/krb5cc_pbs_client -v  -C vchlum -o /tmp/krb5cc_test
Initializing Kerberos
Ticket to convert is host/d12-pbs-server@PBSPRO for krbtgt/PBSPRO@PBSPRO
Target ticket is vchlum@PBSPRO for krbtgt/PBSPRO@PBSPRO
Could not convert ticket: Failed to connect to server d12-kdc (Operation now in progress)


real	0m5.064s
user	0m0.001s
sys	0m0.009s
```
* clients timeout, argument -T:
```
root@d12-pbs-server:~/krb525# iptables -A INPUT --src d12-kdc -p tcp --sport 6565 -j DROP
root@d12-pbs-server:~/krb525# time ./krb525_renew vchlum@PBSPRO -T 2
Failed to translate ticket: Failed to connect to server d12-kdc (Operation now in progress)
.

real	0m2.036s
user	0m0.010s
sys	0m0.007s
root@d12-pbs-server:~/krb525# time ./krb525 -i /tmp/krb5cc_pbs_client -v  -C vchlum -o /tmp/krb5cc_test -T 2
Initializing Kerberos
Ticket to convert is host/d12-pbs-server@PBSPRO for krbtgt/PBSPRO@PBSPRO
Target ticket is vchlum@PBSPRO for krbtgt/PBSPRO@PBSPRO
Could not convert ticket: Failed to connect to server d12-kdc (Operation now in progress)


real	0m2.010s
user	0m0.006s
sys	0m0.001s

```
* clients timeout, krb5.conf parameter:
cat /etc/krb5.conf:
```
.
..
...
[appdefaults]
        krb525_server = d12-kdc
	krb525_timeout = 1
```
```
root@d12-pbs-server:~/krb525# iptables -A INPUT --src d12-kdc -p tcp --sport 6565 -j DROP
root@d12-pbs-server:~/krb525# time ./krb525_renew vchlum@PBSPRO
Failed to translate ticket: Failed to connect to server d12-kdc (Operation now in progress)
.

real	0m1.033s
user	0m0.010s
sys	0m0.003s
root@d12-pbs-server:~/krb525# time ./krb525 -i /tmp/krb5cc_pbs_client -v  -C vchlum -o /tmp/krb5cc_test 
Initializing Kerberos
Ticket to convert is host/d12-pbs-server@PBSPRO for krbtgt/PBSPRO@PBSPRO
Target ticket is vchlum@PBSPRO for krbtgt/PBSPRO@PBSPRO
Could not convert ticket: Failed to connect to server d12-kdc (Operation now in progress)


real	0m1.024s
user	0m0.005s
sys	0m0.009s

```
* client timeout, secondary server:
```
(BOOKWORM)root@torque1:~/krb525# cat /etc/krb5.conf | grep krb525
        krb525_server = kdc1.anonym
        krb525_server = kdc2.anonym
        krb525_server = kdc3.anonym
(BOOKWORM)root@torque1:~/krb525# iptables -A INPUT --src kdc1.anonym -p tcp --sport 6565 -j DROP
(BOOKWORM)root@torque1:~/krb525# time ./krb525_renew vchlum@META -T 3
Type: Kerberos
Valid until: 1722341068
<... anonymized ...>

real	0m3.402s
user	0m0.009s
sys	0m0.013s

```
* server timeout:
```
root@d12-kdc:~/krb525# time ./krb525d -p 6566 -T 3

real	0m3.165s
user	0m0.000s
sys	0m0.010s
```